### PR TITLE
refactor(address): add Display trait

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -34,6 +34,28 @@ impl AddressFormat {
             AddressFormat::Ethereum,
         ]
     }
+
+    /// Returns the character encoding name used by this address format.
+    pub fn charset_name(&self) -> &'static str {
+        match self {
+            AddressFormat::P2pkh | AddressFormat::P2pkhUncompressed | AddressFormat::P2shP2wpkh => "Base58",
+            AddressFormat::P2wpkh | AddressFormat::P2tr => "Bech32",
+            AddressFormat::Ethereum => "Hex",
+        }
+    }
+}
+
+impl std::fmt::Display for AddressFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AddressFormat::P2pkh => write!(f, "P2PKH"),
+            AddressFormat::P2pkhUncompressed => write!(f, "P2PKH (Uncompressed)"),
+            AddressFormat::P2wpkh => write!(f, "P2WPKH"),
+            AddressFormat::P2shP2wpkh => write!(f, "P2SH-P2WPKH"),
+            AddressFormat::P2tr => write!(f, "P2TR"),
+            AddressFormat::Ethereum => write!(f, "Ethereum"),
+        }
+    }
 }
 
 /// A generated address with its private key.
@@ -233,5 +255,25 @@ mod tests {
         let result = gen.generate(&secret).unwrap();
         assert!(result.address.starts_with("0x"));
         assert_eq!(result.address.len(), 42);
+    }
+
+    #[test]
+    fn test_display_format() {
+        assert_eq!(AddressFormat::P2pkh.to_string(), "P2PKH");
+        assert_eq!(AddressFormat::P2wpkh.to_string(), "P2WPKH");
+        assert_eq!(AddressFormat::P2shP2wpkh.to_string(), "P2SH-P2WPKH");
+        assert_eq!(AddressFormat::P2tr.to_string(), "P2TR");
+        assert_eq!(AddressFormat::P2pkhUncompressed.to_string(), "P2PKH (Uncompressed)");
+        assert_eq!(AddressFormat::Ethereum.to_string(), "Ethereum");
+    }
+
+    #[test]
+    fn test_charset_name() {
+        assert_eq!(AddressFormat::P2pkh.charset_name(), "Base58");
+        assert_eq!(AddressFormat::P2pkhUncompressed.charset_name(), "Base58");
+        assert_eq!(AddressFormat::P2shP2wpkh.charset_name(), "Base58");
+        assert_eq!(AddressFormat::P2wpkh.charset_name(), "Bech32");
+        assert_eq!(AddressFormat::P2tr.charset_name(), "Bech32");
+        assert_eq!(AddressFormat::Ethereum.charset_name(), "Hex");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -614,13 +614,7 @@ fn run_search(
     // Validate charset - warn about impossible patterns
     let invalid_chars = pat.validate_charset(config.format);
     if !invalid_chars.is_empty() {
-        let format_name = match config.format {
-            AddressFormat::P2pkh | AddressFormat::P2pkhUncompressed | AddressFormat::P2shP2wpkh => {
-                "Base58"
-            }
-            AddressFormat::P2wpkh | AddressFormat::P2tr => "Bech32",
-            AddressFormat::Ethereum => "Hex",
-        };
+        let format_name = config.format.charset_name();
         let chars_str: String = invalid_chars.iter().collect();
         eprintln!(
             "Warning: Pattern contains characters not valid in {} addresses: '{}'",
@@ -798,14 +792,7 @@ fn run_search(
             address: addr.address.clone(),
             wif: addr.wif.clone(),
             private_key_hex: addr.hex.clone(),
-            format: match config.format {
-                AddressFormat::P2pkh => "P2PKH".to_string(),
-                AddressFormat::P2wpkh => "P2WPKH".to_string(),
-                AddressFormat::P2pkhUncompressed => "P2PKH (Uncompressed)".to_string(),
-                AddressFormat::P2shP2wpkh => "P2SH-P2WPKH".to_string(),
-                AddressFormat::P2tr => "P2TR".to_string(),
-                AddressFormat::Ethereum => "Ethereum".to_string(),
-            },
+            format: config.format.to_string(),
             pattern: pattern.to_string(),
 
             operations: result.operations,
@@ -993,15 +980,7 @@ fn run_tui(
 ) -> Result<()> {
     let pat = Pattern::new(pattern, ignore_case).context("Failed to compile pattern")?;
     let pattern_owned = pattern.to_string();
-    let format_label = match config.format {
-        AddressFormat::P2pkh => "P2PKH",
-        AddressFormat::P2wpkh => "P2WPKH",
-        AddressFormat::P2pkhUncompressed => "P2PKH (Uncompressed)",
-        AddressFormat::P2shP2wpkh => "P2SH-P2WPKH",
-        AddressFormat::P2tr => "P2TR",
-        AddressFormat::Ethereum => "Ethereum",
-    }
-    .to_string();
+    let format_label = config.format.to_string();
 
     let gpu_enabled = gpu_runner.is_some();
 


### PR DESCRIPTION
## Summary

Implements `Display` for `AddressFormat` and adds `charset_name()` method, eliminating 3 duplicated match blocks in `lib.rs`.

Closes #11

## Changes

- `Display` impl on `AddressFormat` → canonical `"P2PKH"`, `"P2WPKH"`, etc.
- `charset_name()` method → `"Base58"` / `"Bech32"` / `"Hex"`
- Replaced 3 inline match blocks (21 lines) with one-liners
- Added tests for both

## Testing

`cargo test` — 49 passed, 0 failed. No new clippy warnings.

---
Co-Authored-By: Aei <256851514+aeitwoen@users.noreply.github.com>