### PR TITLE
refactor: resolve all clippy warnings

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -122,7 +122,7 @@ impl AddressGenerator {
                 let address = match self.format {
                     AddressFormat::P2pkh | AddressFormat::P2pkhUncompressed => {
                         let public_key = private_key.public_key(&self.secp);
-                        Address::p2pkh(&public_key, self.network)
+                        Address::p2pkh(public_key, self.network)
                     }
                     AddressFormat::P2wpkh => {
                         let public_key =
@@ -156,7 +156,7 @@ impl AddressGenerator {
     /// Helper: Generate P2PKH from compressed public key bytes.
     pub fn p2pkh_from_public_key_bytes(bytes: &[u8; 33]) -> Result<String> {
         let pubkey = PublicKey::from_slice(bytes)?;
-        Ok(Address::p2pkh(&pubkey, Network::Bitcoin).to_string())
+        Ok(Address::p2pkh(pubkey, Network::Bitcoin).to_string())
     }
 
     /// Helper: Generate P2WPKH from compressed public key bytes.

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -482,7 +482,7 @@ impl GpuRunner {
             });
             cpass.set_pipeline(&init_pipeline);
             cpass.set_bind_group(0, &frames[0].bind_group, &[]);
-            let workgroups = (batch_size + 255) / 256;
+            let workgroups = batch_size.div_ceil(256);
             cpass.dispatch_workgroups(workgroups, 1, 1);
         }
         queue.submit(Some(encoder.finish()));
@@ -545,7 +545,7 @@ impl GpuRunner {
             });
             cpass.set_pipeline(&self.pipeline);
             cpass.set_bind_group(0, &frame.bind_group, &[]);
-            let workgroups = (self.batch_size + 255) / 256;
+            let workgroups = self.batch_size.div_ceil(256);
             cpass.dispatch_workgroups(workgroups, 1, 1);
         }
 
@@ -576,25 +576,35 @@ impl GpuRunner {
         loop {
             self.device.poll(wgpu::PollType::Poll).map_err(|e| anyhow::anyhow!("Device poll failed: {e:?}"))?;
 
-            let mut guard = frame.receiver.lock().unwrap();
-            if let Some(rx) = guard.as_mut() {
-                match rx.try_recv() {
-                    Ok(res) => {
-                        res?;
-                        *guard = None;
-                        break;
-                    }
-                    Err(tokio::sync::oneshot::error::TryRecvError::Empty) => {
-                        drop(guard);
-                        tokio::task::yield_now().await;
-                        continue;
-                    }
-                    Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {
-                        anyhow::bail!("Sender dropped");
-                    }
+            let status = {
+                let mut guard = frame.receiver.lock().unwrap();
+                match guard.as_mut() {
+                    Some(rx) => match rx.try_recv() {
+                        Ok(res) => {
+                            *guard = None;
+                            Some(Ok(res))
+                        }
+                        Err(tokio::sync::oneshot::error::TryRecvError::Empty) => None,
+                        Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {
+                            Some(Err(anyhow::anyhow!("Sender dropped")))
+                        }
+                    },
+                    None => Some(Err(anyhow::anyhow!(
+                        "No pending operation on frame {}",
+                        frame_index
+                    ))),
                 }
-            } else {
-                anyhow::bail!("No pending operation on frame {}", frame_index);
+            };
+
+            match status {
+                Some(Ok(res)) => {
+                    res?;
+                    break;
+                }
+                Some(Err(e)) => return Err(e),
+                None => {
+                    tokio::task::yield_now().await;
+                }
             }
         }
 
@@ -660,7 +670,7 @@ impl GpuRunner {
                 label: Some("P2TR Search Encoder"),
             });
 
-        let workgroups = (self.batch_size + 255) / 256;
+        let workgroups = self.batch_size.div_ceil(256);
 
         // Step 1: Compute Jacobian points (no normalization)
         {
@@ -713,25 +723,35 @@ impl GpuRunner {
         loop {
             self.device.poll(wgpu::PollType::Poll).map_err(|e| anyhow::anyhow!("Device poll failed: {e:?}"))?;
 
-            let mut guard = frame.receiver.lock().unwrap();
-            if let Some(rx) = guard.as_mut() {
-                match rx.try_recv() {
-                    Ok(res) => {
-                        res?;
-                        *guard = None;
-                        break;
-                    }
-                    Err(tokio::sync::oneshot::error::TryRecvError::Empty) => {
-                        drop(guard);
-                        tokio::task::yield_now().await;
-                        continue;
-                    }
-                    Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {
-                        anyhow::bail!("Sender dropped");
-                    }
+            let status = {
+                let mut guard = frame.receiver.lock().unwrap();
+                match guard.as_mut() {
+                    Some(rx) => match rx.try_recv() {
+                        Ok(res) => {
+                            *guard = None;
+                            Some(Ok(res))
+                        }
+                        Err(tokio::sync::oneshot::error::TryRecvError::Empty) => None,
+                        Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {
+                            Some(Err(anyhow::anyhow!("Sender dropped")))
+                        }
+                    },
+                    None => Some(Err(anyhow::anyhow!(
+                        "No pending operation on frame {}",
+                        frame_index
+                    ))),
                 }
-            } else {
-                anyhow::bail!("No pending operation on frame {}", frame_index);
+            };
+
+            match status {
+                Some(Ok(res)) => {
+                    res?;
+                    break;
+                }
+                Some(Err(e)) => return Err(e),
+                None => {
+                    tokio::task::yield_now().await;
+                }
             }
         }
 
@@ -791,7 +811,7 @@ impl GpuRunner {
                 label: Some("Batch Hash Search Encoder"),
             });
 
-        let workgroups = (self.batch_size + 255) / 256;
+        let workgroups = self.batch_size.div_ceil(256);
 
         // Step 1: Compute Jacobian points
         {
@@ -845,10 +865,10 @@ fn key_to_affine(key: [u8; 32]) -> Result<([u32; 8], [u32; 8])> {
 
     fn bytes_be_to_u32_le(bytes: &[u8]) -> [u32; 8] {
         let mut limbs = [0u32; 8];
-        for i in 0..8 {
+        for (i, limb) in limbs.iter_mut().enumerate() {
             let start = 28 - i * 4;
             let chunk: [u8; 4] = bytes[start..start + 4].try_into().unwrap();
-            limbs[i] = u32::from_be_bytes(chunk);
+            *limb = u32::from_be_bytes(chunk);
         }
         limbs
     }
@@ -893,7 +913,7 @@ pub async fn scan_gpu_with_runner(
         }
     };
 
-    let end_key_bytes = config.end.as_ref().map(|e| biguint_to_bytes32(e));
+    let end_key_bytes = config.end.as_ref().map(biguint_to_bytes32);
     let matches_mutex: Arc<Mutex<Vec<GeneratedAddress>>> = Arc::new(Mutex::new(Vec::new()));
     let found = Arc::new(AtomicUsize::new(0));
 
@@ -1136,7 +1156,7 @@ pub async fn scan_gpu_p2tr_with_runner(
         }
     };
 
-    let end_key_bytes = config.end.as_ref().map(|e| biguint_to_bytes32(e));
+    let end_key_bytes = config.end.as_ref().map(biguint_to_bytes32);
     let matches_mutex: Arc<Mutex<Vec<GeneratedAddress>>> = Arc::new(Mutex::new(Vec::new()));
     let found = Arc::new(AtomicUsize::new(0));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -394,7 +394,7 @@ pub(crate) fn run(cli: Cli) -> Result<()> {
             let private_key = PrivateKey::new(secret_key, Network::Bitcoin);
             let public_key = PublicKey::from_private_key(&secp, &private_key);
 
-            let p2pkh_addr = Address::p2pkh(&public_key, Network::Bitcoin);
+            let p2pkh_addr = Address::p2pkh(public_key, Network::Bitcoin);
             let p2wpkh_addr = CompressedPublicKey::try_from(public_key)
                 .ok()
                 .map(|cpk| Address::p2wpkh(&cpk, Network::Bitcoin));
@@ -572,7 +572,7 @@ fn resolve_range_params(
 
 fn parse_explicit_range(range: Option<String>, puzzle: Option<u32>) -> Result<(BigUint, BigUint)> {
     if let Some(p) = puzzle {
-        if p < 1 || p > 160 {
+        if !(1..=160).contains(&p) {
             anyhow::bail!("Puzzle number must be between 1 and 160");
         }
         let start = BigUint::one() << (p - 1);
@@ -594,6 +594,7 @@ fn parse_explicit_range(range: Option<String>, puzzle: Option<u32>) -> Result<(B
 }
 
 // Unified search runner
+#[allow(clippy::too_many_arguments)]
 fn run_search(
     pattern: &str,
     ignore_case: bool,
@@ -669,7 +670,7 @@ fn run_search(
 
     // TUI path
     if use_tui {
-        let tui_result = run_tui(&pattern, ignore_case, config.clone(), gpu_runner.clone());
+        let tui_result = run_tui(pattern, ignore_case, config.clone(), gpu_runner.clone());
         match tui_result {
             Ok(_) => return Ok(()),
             Err(e) => {
@@ -854,12 +855,14 @@ fn run_search(
         }
     }
 
-    if file.is_some() && !result.matches.is_empty() && !quiet {
-        eprintln!(
-            "Wrote {} result(s) to {:?}",
-            result.matches.len(),
-            file.as_ref().unwrap()
-        );
+    if let Some(f) = file.as_ref() {
+        if !result.matches.is_empty() && !quiet {
+            eprintln!(
+                "Wrote {} result(s) to {:?}",
+                result.matches.len(),
+                f
+            );
+        }
     }
 
     if result.matches.is_empty() && !quiet {
@@ -953,7 +956,7 @@ fn format_with_commas(n: u64) -> String {
     let bytes = s.as_bytes();
     let mut out = String::with_capacity(s.len() + s.len() / 3);
     for (i, &b) in bytes.iter().enumerate() {
-        if i != 0 && (bytes.len() - i) % 3 == 0 {
+        if i != 0 && (bytes.len() - i).is_multiple_of(3) {
             out.push(',');
         }
         out.push(b as char);

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -238,7 +238,7 @@ fn scan_range_cpu(
     };
 
     let batch_size = 10_000u64;
-    let num_batches = (total_keys_u64 + batch_size - 1) / batch_size;
+    let num_batches = total_keys_u64.div_ceil(batch_size);
 
     let scan_loop = || {
         (0..num_batches).into_par_iter().for_each(|batch_idx| {


### PR DESCRIPTION
## Summary
Eliminate all 18 clippy warnings to achieve a clean lint baseline. Most impactful change: restructure MutexGuard scoping in GPU async functions to prevent potential deadlocks.

Closes #13

## Changes
- **gpu.rs**: Restructure `await_result` and `await_result_p2tr` — MutexGuard now scoped to a block and dropped before `.await` (`await_holding_lock`)
- **gpu.rs**: `(x + 255) / 256` → `x.div_ceil(256)` (4×), `.map(|e| fn(e))` → `.map(fn)` (2×), `for i in 0..8` → enumerate (1×)
- **address.rs**: Remove needless borrows in `Address::p2pkh` calls (2×)
- **scanner.rs**: `div_ceil` (1×)
- **lib.rs**: Needless borrows, `manual_range_contains`, `unnecessary_unwrap`, `needless_borrow`, `is_multiple_of`, allow `too_many_arguments` on `run_search` (6×)

## Testing
`cargo clippy` — 0 warnings. `cargo test` — 49/49 pass.

---
Co-Authored-By: Ori <18102267+oritwoen@users.noreply.github.com>