### PR TITLE
fix(estimate): resolve data provider patterns

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -500,6 +500,9 @@ fn resolve_pattern_and_format(
 ) -> Result<(String, AddressFormat)> {
     if let Some(provider_result) = provider::resolve(pattern)? {
         let resolved = if let Some(prefix_len) = prefix_length {
+            if prefix_len == 0 {
+                anyhow::bail!("--prefix-length must be at least 1 for provider patterns");
+            }
             provider::build_pattern(&provider_result, prefix_len)
         } else {
             provider::build_exact_pattern(&provider_result)


### PR DESCRIPTION
`generate` and `range` both resolve provider patterns (like `boha:b1000:66`) into actual regex via `resolve_pattern_and_format()`, but `estimate` was passing the raw string straight to `Pattern::new()`. So `vgen estimate -p boha:b1000:66 -l 8` would just try to compile `boha:b1000:66` as regex instead of resolving it first.

Routed `estimate` through the same `resolve_pattern_and_format()` path. Added `--prefix-length` (`-l`) to match the generate/range interface. Also switched the format display from a hardcoded match to `AddressFormat::Display` since the format might come from the provider now.

Closes #20