### PR TITLE
feat: expose P2SH-P2WPKH as CLI format

### DIFF
--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -1016,6 +1016,16 @@ pub async fn scan_gpu_with_runner(
                             .expect("valid script")
                             .to_string()
                     }
+                    AddressFormat::P2shP2wpkh => {
+                        use bitcoin::hashes::Hash;
+                        use bitcoin::ScriptBuf;
+                        use bitcoin::WPubkeyHash;
+                        let wpkh = WPubkeyHash::from_byte_array(*hash160);
+                        let redeem_script = ScriptBuf::new_p2wpkh(&wpkh);
+                        bitcoin::Address::p2sh(&redeem_script, bitcoin::Network::Bitcoin)
+                            .expect("valid script")
+                            .to_string()
+                    }
                     AddressFormat::Ethereum => {
                         unreachable!("GPU path not supported for Ethereum")
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,6 +214,8 @@ enum Commands {
 enum Format {
     P2pkh,
     P2wpkh,
+    #[value(alias = "p2sh-p2wpkh")]
+    P2shP2wpkh,
     P2tr,
     Ethereum,
 }
@@ -223,6 +225,7 @@ impl From<Format> for AddressFormat {
         match f {
             Format::P2pkh => AddressFormat::P2pkh,
             Format::P2wpkh => AddressFormat::P2wpkh,
+            Format::P2shP2wpkh => AddressFormat::P2shP2wpkh,
             Format::P2tr => AddressFormat::P2tr,
             Format::Ethereum => AddressFormat::Ethereum,
         }
@@ -1560,6 +1563,21 @@ mod tests {
         // It should fall back to CPU instead of hitting unreachable!() in GPU path
         let result = run_from_args([
             "vgen", "range", "--range", "1:FF", "-f", "ethereum", "--no-tui",
+        ]);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_generate_p2sh_p2wpkh() {
+        let result = run_from_args([
+            "vgen",
+            "generate",
+            "-p",
+            "^3",
+            "-f",
+            "p2sh-p2wpkh",
+            "--no-tui",
+            "--no-gpu",
         ]);
         assert!(result.is_ok());
     }


### PR DESCRIPTION
P2SH-P2WPKH (nested SegWit, "3..." addresses) has full internal support - generation, charset validation, difficulty estimation, Display - but no way to reach it from the CLI. Added \`-f p2sh-p2wpkh\` to the Format enum with GPU support through the same Hash160 pipeline that P2PKH and P2WPKH use.

Nested SegWit is still common enough that people scanning for "3..." vanity addresses should be able to do it without workarounds.

Closes #21