### PR TITLE
fix(pattern): validate non-alphanumeric literals inside character classes

### DIFF
--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -624,4 +624,13 @@ mod tests {
         let invalid = pat.validate_charset(AddressFormat::P2pkh);
         assert_eq!(invalid, vec!['.']);
     }
+
+    #[test]
+    fn test_validate_charset_escaped_caret_then_literal_caret() {
+        // [\\^^] has escaped ^ (literal) then ^ (should also be literal, not negation)
+        // Both ^ are invalid in Base58
+        let pat = Pattern::new("^1[\\^^]", false).unwrap();
+        let invalid = pat.validate_charset(AddressFormat::P2pkh);
+        assert_eq!(invalid, vec!['^']);
+    }
 }


### PR DESCRIPTION
Charset validation treated all non-alphanumeric characters as regex metacharacters even inside \`[...]\`, where they're actually literals. \`^1[.]\` can never match a Base58 address (dot isn't in the charset) but passed validation without any warning.

The metacharacter skip now only fires outside character classes. Inside classes, non-alphanumeric chars get added to the member list and participate in the "all members invalid" check like any other literal.

Closes #26