### PR TITLE
feat(skills): add agent skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,30 @@ Patterns use Rust regex syntax:
 - Interactive TUI with real-time statistics
 - Bitcoin Puzzle range scanning built-in
 
+## Agent Skills
+
+This project includes [agent skills](https://skills.sh/) that teach AI coding agents how to use vgen.
+
+### Static skills
+
+Curated by the project author:
+
+```bash
+npx skills add oritwoen/vgen
+```
+
+| Skill | Description |
+|-------|-------------|
+| `vgen` | CLI and library API for Bitcoin vanity address generation with GPU acceleration |
+
+### Dynamic skills
+
+Auto-generated from live docs, issues, and releases using [skilld](https://github.com/harlan-zw/skilld):
+
+```bash
+npx skilld add vgen
+```
+
 ## Roadmap
 
 - [ ] More cryptocurrencies (Litecoin, Dogecoin, Solana, etc.)

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ npx skills add oritwoen/vgen
 Auto-generated from live docs, issues, and releases using [skilld](https://github.com/harlan-zw/skilld):
 
 ```bash
-npx skilld add vgen
+npx skilld add oritwoen/vgen
 ```
 
 ## Roadmap

--- a/skills/vgen/SKILL.md
+++ b/skills/vgen/SKILL.md
@@ -177,7 +177,6 @@ For full type definitions and GPU API details, see [api-reference.md](references
 ## Limitations
 
 - GPU acceleration works for P2PKH, P2WPKH, and P2TR. Other formats fall back to CPU automatically.
-- Case-insensitive matching (`-i`) works with Base58 formats (P2PKH, P2SH-P2WPKH) in `generate` and `estimate` modes. Bech32 and Ethereum addresses have fixed casing, so `-i` is redundant there.
-- Ethereum format is CPU-only in `range` mode.
+- Case-insensitive matching (`-i`) works with Base58 formats (P2PKH, P2SH-P2WPKH) and Ethereum (EIP-55 mixed-case) in `generate` and `estimate` modes. Bech32 addresses are always lowercase, so `-i` is redundant for P2WPKH/P2TR.
 - `--prefix-length` must be at least 1 when used.
 - This is experimental software. Do not use generated keys for real funds without thorough verification.

--- a/skills/vgen/SKILL.md
+++ b/skills/vgen/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vgen
-description: Query package metadata from vgen, a Bitcoin vanity address generator with regex pattern matching and GPU acceleration. Use when generating Bitcoin/Ethereum vanity addresses, scanning key ranges for Bitcoin Puzzles, or verifying private keys against addresses. Supports P2PKH, P2WPKH, P2SH-P2WPKH, P2TR, and Ethereum formats.
+description: Bitcoin vanity address generator with regex pattern matching and GPU acceleration. Use when generating Bitcoin/Ethereum vanity addresses, scanning key ranges for Bitcoin Puzzles, or verifying private keys against addresses. Supports P2PKH, P2WPKH, P2SH-P2WPKH, P2TR, and Ethereum formats.
 metadata:
   author: oritwoen
   version: "0.2.0"
@@ -20,7 +20,7 @@ Supports P2PKH (`1...`), P2WPKH (`bc1q...`), P2SH-P2WPKH (`3...`), P2TR (`bc1p..
 # P2PKH starting with "1Cat"
 vgen generate -p "^1Cat"
 
-# Case insensitive (P2PKH only)
+# Case insensitive (Base58 + Ethereum)
 vgen generate -p "^1cat" -i
 
 # Bech32 ending with "dead"

--- a/skills/vgen/SKILL.md
+++ b/skills/vgen/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: vgen
+description: Query package metadata from vgen, a Bitcoin vanity address generator with regex pattern matching and GPU acceleration. Use when generating Bitcoin/Ethereum vanity addresses, scanning key ranges for Bitcoin Puzzles, or verifying private keys against addresses. Supports P2PKH, P2WPKH, P2SH-P2WPKH, P2TR, and Ethereum formats.
+metadata:
+  author: oritwoen
+  version: "0.2.0"
+---
+
+# vgen
+
+Bitcoin vanity address generator. Finds private keys whose derived addresses match regex patterns. GPU-accelerated via wgpu (Vulkan/Metal/DX12/GL), falls back to CPU automatically.
+
+Supports P2PKH (`1...`), P2WPKH (`bc1q...`), P2SH-P2WPKH (`3...`), P2TR (`bc1p...`), and Ethereum (`0x...`).
+
+## Using the CLI
+
+### Generate vanity address
+
+```bash
+# P2PKH starting with "1Cat"
+vgen generate -p "^1Cat"
+
+# Case insensitive (P2PKH only)
+vgen generate -p "^1cat" -i
+
+# Bech32 ending with "dead"
+vgen generate -p "dead$" -f p2wpkh
+
+# Ethereum
+vgen generate -p "^0xdead" -f ethereum
+
+# Find 5 matches, JSON output to file
+vgen generate -p "^1Cat" -c 5 -o jsonl --file results.jsonl
+
+# CPU only
+vgen generate -p "^1Cat" --no-gpu
+```
+
+### Scan key range (Bitcoin Puzzles)
+
+```bash
+# Manual hex range
+vgen range -r "2000:3FFF"
+
+# Auto range from puzzle number
+vgen range --puzzle 66
+
+# With data provider (resolves address + range automatically)
+vgen range -p "boha:b1000:66"
+
+# Prefix matching with provider
+vgen range -p "boha:b1000:66" -l 8
+
+# Scan entire range (no early stop)
+vgen range --puzzle 66 -c 0
+```
+
+### Verify private key
+
+```bash
+# From WIF
+vgen verify -k "5HueCGU8rMjxEXxiPuD5BDku4MkFqeZyd4dZ1jvhTVqvbTLvyTJ"
+
+# From hex
+vgen verify -k "0c28fca386c7a227600b2fe50b7cae11ec86d3bf1fbe471be89827e19d72aa1d"
+
+# Verify against expected address
+vgen verify -k "KEY" -a "1GAehh7TsJAHuUAeKZcXf5CnwuGuGgyX2S"
+```
+
+### Estimate difficulty
+
+```bash
+vgen estimate -p "^1Cat" -f p2pkh
+```
+
+### Common flags
+
+| Flag | Description |
+|------|-------------|
+| `-p, --pattern` | Regex pattern or data provider ref (`boha:collection:id`) |
+| `-f, --format` | `p2pkh`, `p2wpkh`, `p2sh-p2wpkh`, `p2tr`, `ethereum` |
+| `-o, --output` | `text`, `json`, `jsonl`, `csv`, `minimal` (just WIF) |
+| `--file` | Write output to file instead of stdout |
+| `-c, --count` | Stop after N matches (default: 1, 0 = unlimited) |
+| `-t, --threads` | CPU thread count (default: all) |
+| `--no-gpu` | Force CPU-only |
+| `--gpu-batch-size` | GPU batch size (default: 524288) |
+| `--backend` | `auto`, `vulkan`, `metal`, `dx12`, `gl` |
+| `-i, --ignore-case` | Case insensitive (P2PKH only, generate only) |
+| `-l, --prefix-length` | Use first N chars of provider address as prefix |
+| `--no-tui` | Disable interactive TUI (range only) |
+
+## Pattern syntax
+
+Standard Rust regex. Patterns match against the full generated address.
+
+| Pattern | Matches |
+|---------|---------|
+| `^1Cat` | Address starting with `1Cat` |
+| `dead$` | Address ending with `dead` |
+| `^1[Cc]at` | `1Cat` or `1cat` |
+| `^1.*dead$` | Starts with `1`, ends with `dead` |
+
+Be aware of charset constraints per format - P2PKH uses Base58 (no `0`, `O`, `I`, `l`), Bech32 is lowercase only.
+
+## Data providers
+
+Pattern can be a provider reference instead of regex. Format: `provider:collection:id`.
+
+Currently supported:
+- `boha:collection:id` - [boha](https://github.com/oritwoen/boha) puzzle library
+
+In `range` mode, providers auto-resolve both the target address (as regex) and the key range. With `-l N`, only the first N characters become the prefix pattern.
+
+## Using the Library API
+
+### Install
+
+```bash
+cargo add vgen
+```
+
+### Key types
+
+```rust
+use vgen::{
+    AddressFormat,       // P2pkh, P2wpkh, P2shP2wpkh, P2tr, Ethereum
+    AddressGenerator,    // Generates addresses from secret keys
+    GeneratedAddress,    // Result: address + WIF + format
+    Pattern,             // Compiled regex pattern
+    ScanConfig,          // Scanner configuration
+    ScanResult,          // Scan results with matches and stats
+    scan,                // One-shot CPU scan
+    scan_with_progress,  // CPU scan with progress callback
+    GpuRunner,           // GPU scanner
+    GpuBackend,          // Vulkan/Metal/DX12/GL/Auto
+};
+```
+
+### CPU scan
+
+```rust
+use vgen::{Pattern, ScanConfig, AddressFormat, scan};
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+
+let pattern = Pattern::new("^1Cat", false)?;
+let config = ScanConfig {
+    pattern: Arc::new(pattern),
+    format: AddressFormat::P2pkh,
+    threads: num_cpus::get(),
+    count: 1,
+};
+let stop = Arc::new(AtomicBool::new(false));
+let result = scan(&config, stop);
+for addr in &result.matches {
+    println!("{} {}", addr.address, addr.private_key);
+}
+```
+
+### Address generation
+
+```rust
+use vgen::{AddressFormat, AddressGenerator};
+
+let gen = AddressGenerator::new(AddressFormat::P2pkh);
+let addr = gen.generate_random();
+// addr.address, addr.private_key, addr.format
+```
+
+For full type definitions and GPU API details, see [api-reference.md](references/api-reference.md).
+
+## References
+
+| When | Read |
+|------|------|
+| Full type definitions, GPU API, ScanConfig fields | [api-reference.md](references/api-reference.md) |
+
+## Limitations
+
+- GPU acceleration works for P2PKH, P2WPKH, and P2TR. Other formats fall back to CPU automatically.
+- Case insensitive matching (`-i`) only works with P2PKH in `generate` mode.
+- Ethereum format is CPU-only in `range` mode.
+- `--prefix-length` must be at least 1 when used.
+- This is experimental software. Do not use generated keys for real funds without thorough verification.

--- a/skills/vgen/SKILL.md
+++ b/skills/vgen/SKILL.md
@@ -87,7 +87,7 @@ vgen estimate -p "^1Cat" -f p2pkh
 | `--no-gpu` | Force CPU-only |
 | `--gpu-batch-size` | GPU batch size (default: 524288) |
 | `--backend` | `auto`, `vulkan`, `metal`, `dx12`, `gl` |
-| `-i, --ignore-case` | Case insensitive (P2PKH only, generate only) |
+| `-i, --ignore-case` | Case insensitive (Base58 + Ethereum, generate/estimate) |
 | `-l, --prefix-length` | Use first N chars of provider address as prefix |
 | `--no-tui` | Disable interactive TUI (range only) |
 

--- a/skills/vgen/SKILL.md
+++ b/skills/vgen/SKILL.md
@@ -142,20 +142,16 @@ use vgen::{
 
 ```rust
 use vgen::{Pattern, ScanConfig, AddressFormat, scan};
-use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
 
 let pattern = Pattern::new("^1Cat", false)?;
 let config = ScanConfig {
-    pattern: Arc::new(pattern),
     format: AddressFormat::P2pkh,
-    threads: num_cpus::get(),
     count: 1,
+    ..ScanConfig::default()
 };
-let stop = Arc::new(AtomicBool::new(false));
-let result = scan(&config, stop);
+let result = scan(&pattern, &config);
 for addr in &result.matches {
-    println!("{} {}", addr.address, addr.private_key);
+    println!("{} {} {}", addr.address, addr.wif, addr.hex);
 }
 ```
 
@@ -165,8 +161,9 @@ for addr in &result.matches {
 use vgen::{AddressFormat, AddressGenerator};
 
 let gen = AddressGenerator::new(AddressFormat::P2pkh);
-let addr = gen.generate_random();
-// addr.address, addr.private_key, addr.format
+let secret = [1u8; 32]; // your 32-byte secret key
+let addr = gen.generate(&secret).expect("valid key");
+// addr.address, addr.wif, addr.hex, addr.format
 ```
 
 For full type definitions and GPU API details, see [api-reference.md](references/api-reference.md).
@@ -180,7 +177,7 @@ For full type definitions and GPU API details, see [api-reference.md](references
 ## Limitations
 
 - GPU acceleration works for P2PKH, P2WPKH, and P2TR. Other formats fall back to CPU automatically.
-- Case insensitive matching (`-i`) only works with P2PKH in `generate` mode.
+- Case-insensitive matching (`-i`) only works with P2PKH in `generate` mode.
 - Ethereum format is CPU-only in `range` mode.
 - `--prefix-length` must be at least 1 when used.
 - This is experimental software. Do not use generated keys for real funds without thorough verification.

--- a/skills/vgen/SKILL.md
+++ b/skills/vgen/SKILL.md
@@ -160,9 +160,9 @@ for addr in &result.matches {
 ```rust
 use vgen::{AddressFormat, AddressGenerator};
 
-let gen = AddressGenerator::new(AddressFormat::P2pkh);
+let generator = AddressGenerator::new(AddressFormat::P2pkh);
 let secret = [1u8; 32]; // your 32-byte secret key
-let addr = gen.generate(&secret).expect("valid key");
+let addr = generator.generate(&secret).expect("valid key");
 // addr.address, addr.wif, addr.hex, addr.format
 ```
 
@@ -177,7 +177,7 @@ For full type definitions and GPU API details, see [api-reference.md](references
 ## Limitations
 
 - GPU acceleration works for P2PKH, P2WPKH, and P2TR. Other formats fall back to CPU automatically.
-- Case-insensitive matching (`-i`) only works with P2PKH in `generate` mode.
+- Case-insensitive matching (`-i`) works with Base58 formats (P2PKH, P2SH-P2WPKH) in `generate` and `estimate` modes. Bech32 and Ethereum addresses have fixed casing, so `-i` is redundant there.
 - Ethereum format is CPU-only in `range` mode.
 - `--prefix-length` must be at least 1 when used.
 - This is experimental software. Do not use generated keys for real funds without thorough verification.

--- a/skills/vgen/references/api-reference.md
+++ b/skills/vgen/references/api-reference.md
@@ -7,7 +7,7 @@
 ```rust
 pub enum AddressFormat {
     P2pkh,              // 1... (Base58, compressed)
-    P2pkhUncompressed,  // 1... (Base58, uncompressed)
+    P2pkhUncompressed,  // 1... (Base58, uncompressed) - library-only, not in CLI
     P2wpkh,             // bc1q... (Bech32)
     P2shP2wpkh,         // 3... (Base58)
     P2tr,               // bc1p... (Bech32m)

--- a/skills/vgen/references/api-reference.md
+++ b/skills/vgen/references/api-reference.md
@@ -33,7 +33,7 @@ pub struct Pattern { /* ... */ }
 
 impl Pattern {
     // Compile regex. Returns Err on empty or invalid pattern.
-    pub fn new(pattern: &str, case_insensitive: bool) -> Result<Self>;
+    pub fn new(pattern: &str, case_insensitive: bool) -> anyhow::Result<Self>;
 
     // Test if address matches the pattern.
     pub fn matches(&self, address: &str) -> bool;
@@ -106,7 +106,7 @@ pub struct GpuRunner { /* ... */ }
 
 impl GpuRunner {
     // Initialize GPU with given batch size and backend preference.
-    pub async fn new(batch_size: u32, backend: GpuBackend) -> Result<Self>;
+    pub async fn new(batch_size: u32, backend: GpuBackend) -> anyhow::Result<Self>;
 
     pub fn backend(&self) -> GpuBackend;
 }
@@ -118,7 +118,7 @@ pub async fn scan_gpu_with_runner(
     progress_cb: Option<ProgressCallback>,
     stop: Option<Arc<AtomicBool>>,
     runner: Arc<GpuRunner>,
-) -> Result<ScanResult>;
+) -> anyhow::Result<ScanResult>;
 
 // High-level GPU scan for P2TR (Taproot).
 pub async fn scan_gpu_p2tr_with_runner(
@@ -127,7 +127,7 @@ pub async fn scan_gpu_p2tr_with_runner(
     progress_cb: Option<ProgressCallback>,
     stop: Option<Arc<AtomicBool>>,
     runner: Arc<GpuRunner>,
-) -> Result<ScanResult>;
+) -> anyhow::Result<ScanResult>;
 ```
 
 GPU is not available for Ethereum or P2SH-P2WPKH - these fall back to CPU.

--- a/skills/vgen/references/api-reference.md
+++ b/skills/vgen/references/api-reference.md
@@ -82,15 +82,15 @@ impl ScanResult {
 ## Scanner functions
 
 ```rust
-// One-shot CPU scan. Blocks until `count` matches found or `stop` signaled.
+// One-shot CPU scan. Blocks until `count` matches found.
 pub fn scan(pattern: &Pattern, config: &ScanConfig) -> ScanResult;
 
-// CPU scan with progress callback (called with cumulative key count).
+// CPU scan with optional progress callback and stop flag.
 pub fn scan_with_progress(
     pattern: &Pattern,
     config: &ScanConfig,
-    stop: Arc<AtomicBool>,
-    callback: ProgressCallback,
+    progress_callback: Option<ProgressCallback>,
+    stop_flag: Option<Arc<AtomicBool>>,
 ) -> ScanResult;
 
 pub type ProgressCallback = Arc<dyn Fn(u64) + Send + Sync>;
@@ -113,20 +113,20 @@ impl GpuRunner {
 
 // High-level GPU scan for hash-based formats (P2PKH, P2WPKH).
 pub async fn scan_gpu_with_runner(
-    runner: &GpuRunner,
     pattern: &Pattern,
     config: &ScanConfig,
-    stop: Arc<AtomicBool>,
-    callback: ProgressCallback,
+    progress_cb: Option<ProgressCallback>,
+    stop: Option<Arc<AtomicBool>>,
+    runner: Arc<GpuRunner>,
 ) -> Result<ScanResult>;
 
 // High-level GPU scan for P2TR (Taproot).
 pub async fn scan_gpu_p2tr_with_runner(
-    runner: &GpuRunner,
     pattern: &Pattern,
     config: &ScanConfig,
-    stop: Arc<AtomicBool>,
-    callback: ProgressCallback,
+    progress_cb: Option<ProgressCallback>,
+    stop: Option<Arc<AtomicBool>>,
+    runner: Arc<GpuRunner>,
 ) -> Result<ScanResult>;
 ```
 
@@ -139,8 +139,8 @@ pub struct AddressGenerator { /* Secp256k1 context + network + format */ }
 
 impl AddressGenerator {
     pub fn new(format: AddressFormat) -> Self;
-    pub fn generate_random(&self) -> GeneratedAddress;
-    pub fn generate_from_key(&self, secret_key: &[u8; 32]) -> GeneratedAddress;
+    // Generate address from a 32-byte secret key. Returns None if key is invalid.
+    pub fn generate(&self, secret: &[u8; 32]) -> Option<GeneratedAddress>;
 }
 ```
 

--- a/skills/vgen/references/api-reference.md
+++ b/skills/vgen/references/api-reference.md
@@ -1,0 +1,149 @@
+# vgen Library API Reference
+
+## Core types
+
+### AddressFormat
+
+```rust
+pub enum AddressFormat {
+    P2pkh,              // 1... (Base58, compressed)
+    P2pkhUncompressed,  // 1... (Base58, uncompressed)
+    P2wpkh,             // bc1q... (Bech32)
+    P2shP2wpkh,         // 3... (Base58)
+    P2tr,               // bc1p... (Bech32m)
+    Ethereum,           // 0x... (Hex, EIP-55 checksum)
+}
+```
+
+### GeneratedAddress
+
+```rust
+pub struct GeneratedAddress {
+    pub address: String,       // The generated address
+    pub wif: String,           // WIF private key (Bitcoin) or hex (Ethereum)
+    pub hex: String,           // Hex-encoded 32-byte private key
+    pub format: AddressFormat,
+}
+```
+
+### Pattern
+
+```rust
+pub struct Pattern { /* ... */ }
+
+impl Pattern {
+    // Compile regex. Returns Err on empty or invalid pattern.
+    pub fn new(pattern: &str, case_insensitive: bool) -> Result<Self>;
+
+    // Test if address matches the pattern.
+    pub fn matches(&self, address: &str) -> bool;
+
+    // Returns chars in pattern that are invalid for the given format's charset.
+    pub fn validate_charset(&self, format: AddressFormat) -> Vec<char>;
+
+    // Estimate number of addresses to check before finding a match.
+    pub fn estimate_difficulty(&self, format: AddressFormat) -> u64;
+
+    pub fn original(&self) -> &str;
+    pub fn is_case_insensitive(&self) -> bool;
+}
+```
+
+### ScanConfig
+
+```rust
+pub struct ScanConfig {
+    pub format: AddressFormat,
+    pub count: usize,                // Matches to find before stopping
+    pub threads: Option<usize>,      // None = all CPUs
+    pub gpu_batch_size: Option<u32>, // Default: 524288
+    pub cpu_batch_size: Option<usize>,
+    pub start: Option<BigUint>,      // Range scan start (None = random)
+    pub end: Option<BigUint>,        // Range scan end
+}
+```
+
+Default: `P2pkh`, count 1, all threads, no range.
+
+### ScanResult
+
+```rust
+pub struct ScanResult {
+    pub matches: Vec<GeneratedAddress>,
+    pub operations: u64,       // Total keys checked
+    pub elapsed_secs: f64,
+}
+
+impl ScanResult {
+    pub fn rate(&self) -> f64; // keys/sec
+}
+```
+
+## Scanner functions
+
+```rust
+// One-shot CPU scan. Blocks until `count` matches found or `stop` signaled.
+pub fn scan(pattern: &Pattern, config: &ScanConfig) -> ScanResult;
+
+// CPU scan with progress callback (called with cumulative key count).
+pub fn scan_with_progress(
+    pattern: &Pattern,
+    config: &ScanConfig,
+    stop: Arc<AtomicBool>,
+    callback: ProgressCallback,
+) -> ScanResult;
+
+pub type ProgressCallback = Arc<dyn Fn(u64) + Send + Sync>;
+
+// Benchmark raw key generation speed (no pattern matching).
+pub fn benchmark(format: AddressFormat, iterations: u64) -> f64;
+```
+
+## GPU API
+
+```rust
+pub struct GpuRunner { /* ... */ }
+
+impl GpuRunner {
+    // Initialize GPU with given batch size and backend preference.
+    pub async fn new(batch_size: u32, backend: GpuBackend) -> Result<Self>;
+
+    pub fn backend(&self) -> GpuBackend;
+}
+
+// High-level GPU scan for hash-based formats (P2PKH, P2WPKH).
+pub async fn scan_gpu_with_runner(
+    runner: &GpuRunner,
+    pattern: &Pattern,
+    config: &ScanConfig,
+    stop: Arc<AtomicBool>,
+    callback: ProgressCallback,
+) -> Result<ScanResult>;
+
+// High-level GPU scan for P2TR (Taproot).
+pub async fn scan_gpu_p2tr_with_runner(
+    runner: &GpuRunner,
+    pattern: &Pattern,
+    config: &ScanConfig,
+    stop: Arc<AtomicBool>,
+    callback: ProgressCallback,
+) -> Result<ScanResult>;
+```
+
+GPU is not available for Ethereum or P2SH-P2WPKH - these fall back to CPU.
+
+## AddressGenerator
+
+```rust
+pub struct AddressGenerator { /* Secp256k1 context + network + format */ }
+
+impl AddressGenerator {
+    pub fn new(format: AddressFormat) -> Self;
+    pub fn generate_random(&self) -> GeneratedAddress;
+    pub fn generate_from_key(&self, secret_key: &[u8; 32]) -> GeneratedAddress;
+}
+```
+
+## Provider module
+
+The `provider` module resolves data provider references (`boha:collection:id`) into address and range data. This is used internally by the CLI - library users typically construct `Pattern` and `ScanConfig` directly.


### PR DESCRIPTION
AI agents using vgen had to read through the entire source to figure out CLI flags, address formats, and library types. Now there's a structured skill in `skills/vgen/` that gives them everything upfront - commands, patterns, GPU options, the full public API with types.

`SKILL.md` covers CLI usage (generate, range, verify, estimate) and library basics. `references/api-reference.md` has the complete type definitions for agents that need to write integration code. README gets an Agent Skills section with install instructions for both static and dynamic skills.

Closes #38